### PR TITLE
feat: use $XDG_STATE_HOME for the cookie file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A set of utilities for managing AUR votes
 ## aur-vote
 > NOTE: If you have `aurutils` installed, `aur vote` may be used instead.
 
-If necessary, `aur-vote` will prompt for authentication. Cookies are saved in `$XDG_DATA_HOME/aurvote-utils/cookie`
-and are renewed automatically. Alternatively, you may regenerate the cookie manually:
+If necessary, `aur-vote` will prompt for authentication. Cookies are saved in `$XDG_STATE_HOME/aurvote-utils/cookie`
+(by default ~/.local/state/...) and are renewed automatically. Alternatively, you may regenerate the cookie manually:
 
 ```
 $ aur-vote -a

--- a/aur-vote
+++ b/aur-vote
@@ -17,8 +17,8 @@ PACKAGE_URL_TEMPLATE = "https://aur.archlinux.org/packages/%s/"
 VOTE_URL_TEMPLATE = "https://aur.archlinux.org/pkgbase/%s/vote/"
 UNVOTE_URL_TEMPLATE = "https://aur.archlinux.org/pkgbase/%s/unvote/"
 
-DATA_PATH = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share")) + "/aurvote-utils"
-COOKIE_PATH = f"{DATA_PATH}/cookie"
+STATE_PATH = os.getenv("XDG_STATE_HOME", os.path.expanduser("~/.local/state")) + "/aurvote-utils"
+COOKIE_PATH = f"{STATE_PATH}/cookie"
 
 Package = collections.namedtuple("Package", ("name", "version", "votes", "popularity", "voted", "notify", "description", "maintainer"))
 


### PR DESCRIPTION
Store the cookie file in $XDG_STATE_HOME (defaulting to ~/.local/state) instead of $XDG_DATA_HOME, adhering to the XDG Base Dir specification:

> The $XDG_STATE_HOME contains state data that should persist between (application) restarts, but that is not important or portable enough to the user that it should be stored in $XDG_DATA_HOME.

Reference: https://specifications.freedesktop.org/basedir-spec/latest/
